### PR TITLE
Fetch `arm64` binaries when run in docker on macOS (`aarch64`)

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -31,6 +31,9 @@ get_arch() {
 	if [ "$ARCH" = "x86_64" ]; then
 		ARCH="amd64"
 	fi
+	if [ "$ARCH" = "aarch64" ]; then
+		ARCH="arm64"
+	fi
 	echo "$ARCH"
 }
 


### PR DESCRIPTION
## Praise

On my Apple Silicon mac this plugin works really well and gets `darwin/arm64` binaries correctly. 🙇 🙏 

## Problem

However if I run this plugin inside a docker image on my mac, I get: 🤔 

```shell
$  > [myapplication-with-asdf 10/28] RUN asdf install container-structure-test:
0.087
0.087 ---------------------
0.087 *   Download info
0.087 ---------------------
0.087 	url: https://github.com/GoogleContainerTools/container-structure-test/releases/download/v1.19.3/container-structure-test-linux-aarch64
0.087 	tool: container-structure-test
0.087 	version: v1.19.3
0.087 	downloaded_filename: /home/someuser/.asdf/downloads/container-structure-test/1.19.3/container-structure-test
0.087 ---------------------
0.087
0.087 Download in progress...
0.409 curl: (22) The requested URL returned error: 404
0.419 asdf-container-structure-test: Could not download https://github.com/GoogleContainerTools/container-structure-test/releases/download/v1.19.3/container-structure-test-linux-aarch64
0.420 error installing version: failed to run download callback: exit status 1
------
Dockerfile:51
--------------------
  51 | >>> RUN asdf install container-structure-test
```

## Solution

So we can improve this by using `arm64` as the `ARCH` in those cases. ✅ 

## Proof

Examples of how it works on my machine:
```shell
# ARCH on my computer:
$ uname -m -s
Darwin arm64

# ARCH inside a linux amd64 platform docker container:
$ docker run --platform=linux/amd64 --rm -it docker.io/library/ubuntu:22.04 uname -m
x86_64

# ARCH inside a linux arm64 platform docker container:
$ docker run --platform=linux/arm64 --rm -it docker.io/library/ubuntu:22.04 uname -m
aarch64
```